### PR TITLE
More bugfixes

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: mamba-org/setup-micromamba@v1
       - name: Setup Mantid
         run: |
-          $MAMBA_EXE create -n cfutils -c mantid mantidworkbench
+          $MAMBA_EXE create -n cfutils -c mantid mantidworkbench mslice
       - name: Test
         run: |
           eval "$($MAMBA_EXE shell activate cfutils)"


### PR DESCRIPTION
* Fix syms bug in original Mantid code (missing `B66`/`IB66` in `C2*` symmetry)
* Add handling for degenerate levels
  - If input has no degeneracies will match each input
  - level with nearest full manifold
  - If input has degeneracies will respect this (prev behaviour)
* Add pseudovoigt handling to `fit_cef` (prev just `fit_en`)